### PR TITLE
split usePokemon as hook folder

### DIFF
--- a/src/components/NameInput/NameInput.js
+++ b/src/components/NameInput/NameInput.js
@@ -1,23 +1,8 @@
 import "./NameInput.scss"
-import { registerHtml, useState, useGlobalState, useEffect } from "tram-one"
-import Pokedex from 'pokedex-promise-v2'
-const PokeAPI = new Pokedex()
+import { registerHtml } from "tram-one"
+import usePokemon from '../../hooks/usePokemon'
 
 const html = registerHtml()
-
-const usePokemon = () => {
-  const [pokemonName, setPokemonName] = useState('')
-  const [pokemon, setPokemon] = useGlobalState('pokemon', null)
-
-  const onUpdatePokemonName = (event) => setPokemonName(event.target.value)
-
-  useEffect(async () => {
-    const fetchedPokemon = await PokeAPI.getPokemonByName(pokemonName.toLowerCase())
-    setPokemon(fetchedPokemon)
-  }, [pokemonName])
-
-  return { pokemon, pokemonName, onUpdatePokemonName }
-}
 
 export default () => {
   const {pokemonName, onUpdatePokemonName} = usePokemon()

--- a/src/components/PokeImage/PokeImage.js
+++ b/src/components/PokeImage/PokeImage.js
@@ -1,13 +1,14 @@
 import "./PokeImage.scss"
-import { registerHtml, useGlobalState } from "tram-one"
+import { registerHtml } from "tram-one"
 import PokeBallImage from "./PokeBallImage"
+import usePokemon from '../../hooks/usePokemon'
 
 const html = registerHtml({
   PokeBallImage
 })
 
 export default () => {
-  const [pokemon] = useGlobalState('pokemon', null)
+  const { pokemon } = usePokemon()
 
   if (!pokemon) {
     return html`<PokeBallImage />`

--- a/src/components/PokemonTypes/PokemonTypes.js
+++ b/src/components/PokemonTypes/PokemonTypes.js
@@ -1,12 +1,13 @@
 import { registerHtml, useGlobalState } from "tram-one"
 import TypeBadge from "../TypeBadge";
+import usePokemon from "../../hooks/usePokemon";
 
 const html = registerHtml({
   TypeBadge
 })
 
 export default () => {
-  const [pokemon] = useGlobalState('pokemon', null)
+  const { pokemon } = usePokemon()
 
   const types = pokemon && pokemon.types.map(({type: {name}}) => html`<TypeBadge type=${name}/>`)
 

--- a/src/hooks/usePokemon/index.js
+++ b/src/hooks/usePokemon/index.js
@@ -1,0 +1,1 @@
+export { default } from './usePokemon'

--- a/src/hooks/usePokemon/usePokemon.js
+++ b/src/hooks/usePokemon/usePokemon.js
@@ -1,0 +1,17 @@
+import { useState, useGlobalState, useEffect } from "tram-one"
+import Pokedex from 'pokedex-promise-v2'
+const PokeAPI = new Pokedex()
+
+export default () => {
+  const [pokemonName, setPokemonName] = useState('')
+  const [pokemon, setPokemon] = useGlobalState('pokemon', null)
+
+  const onUpdatePokemonName = (event) => setPokemonName(event.target.value)
+
+  useEffect(async () => {
+    const fetchedPokemon = await PokeAPI.getPokemonByName(pokemonName.toLowerCase())
+    setPokemon(fetchedPokemon)
+  }, [pokemonName])
+
+  return { pokemon, pokemonName, onUpdatePokemonName }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import "babel-polyfill"
 import "./styles.css"
-import { registerHtml, useGlobalState, start } from "tram-one"
+import { registerHtml, start } from "tram-one"
 
 import ColorHeader from "./components/ColorHeader"
 import NameInput from "./components/NameInput"


### PR DESCRIPTION
## Summary

usePokemon is split off as a hook that can be imported. If we need to keep track of multiple pokemon in the future, we could pass an index like:
```javascript
const { pokemon } = usePokemon(0)
```

Otherwise, as far as keeping track of a single pokemon, this will help since we can use the same hook (and interface for that hook).